### PR TITLE
flake: use core over top-level

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,16 +5,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714602819,
-        "narHash": "sha256-U/emV+rC0ssCNvOdlKRt4K9AUzrQcGW3PzvD6E/NNKg=",
+        "lastModified": 1714776728,
+        "narHash": "sha256-Hs7WOGPk4Kolg4pPTihPGGPOAfCl6+As67pDJkOb/DM=",
         "owner": "auxolotl",
-        "repo": "packages",
-        "rev": "48b022083ffb6e2f1dbfec08411a08f63149b8a0",
+        "repo": "core",
+        "rev": "cbe7a41cc89ccda6bfd14da7c2a8cf982ca07d24",
         "type": "github"
       },
       "original": {
         "owner": "auxolotl",
-        "repo": "packages",
+        "repo": "core",
         "type": "github"
       }
     },
@@ -36,26 +36,7 @@
     },
     "root": {
       "inputs": {
-        "top-level": "top-level"
-      }
-    },
-    "top-level": {
-      "inputs": {
-        "core": "core",
-        "javascript": []
-      },
-      "locked": {
-        "lastModified": 1714721914,
-        "narHash": "sha256-NM84dgutDOxTo4mIrXRWI9C32saFQvfQtq/JeG+MvUU=",
-        "owner": "auxolotl",
-        "repo": "top-level",
-        "rev": "a0907c348e5b71d5c413e4cdc297c0c538b996e4",
-        "type": "github"
-      },
-      "original": {
-        "owner": "auxolotl",
-        "repo": "top-level",
-        "type": "github"
+        "core": "core"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,14 +1,27 @@
 {
   inputs = {
-    top-level = {
-      url = "github:auxolotl/top-level";
-      inputs.javascript.follows = "";
-    };
+    core.url = "github:auxolotl/core";
   };
 
-  outputs = { self, top-level }: {
-    topLevelOut = core: {
-      test = top-level.core.nixPackages."x86_64-linux".hello;
+  outputs =
+    { self, core }:
+    let
+      forAllSystems =
+        function:
+        core.lib.genAttrs core.lib.systems.flakeExposed (
+          system:
+          function {
+            nixPackages = core.nixPackages.${system};
+            # auxPackages = core.auxPackages.${system};
+          }
+        );
+    in
+    {
+      packages = forAllSystems (
+        { nixPackages, ... }:
+        {
+          test = nixPackages.hello;
+        }
+      );
     };
-  };
 }


### PR DESCRIPTION
i'm suggesting this for a few reasons:

- circular dependencies for little reason
  - `top-level` depending on this repo and vice versa doesn't make much sense and adds unnecessary complication
  - anything we want to re-use across repos should be in `core` -- as it's described
- this repo should be able to be used individually
  - if someone only wants to use javascript for example, they shouldn't need to pull in all of `top-level` to do that. i think depending on `top-level` for each individual repo really defeats the purpose of having separate repos

there can be some issues here, though. for example: issues could arise in `top-level` that aren't present here if there's a mismatch in the locked `core` (this is assuming we override the `core` input...which we probably should to not create a lot of dependency bloat). i think this could be solved with some simple CI and automated updates for both repositories - which imo is well worth keeping these repos independent of each other

i would like to see this in future repos as well (i.e., go, rust, haskell, etc), as core should remain the "common set of packages and tools" and `top-level` the actual top-level set

this also depends on https://github.com/auxolotl/packages/pull/4, so this will remain a draft until that is(n't) merged
